### PR TITLE
Move the staging app to use the staging CF environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ db.sqlite3
 *.pyc
 static/
 .cache
+deploy_billing.yml

--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ link and create a user-provided-service using the credentials.
 cf cups customer-uaa-creds -p '{"UAA_CLIENT_ID": "client-id", "UAA_CLIENT_SECRET": "client_secret"}'
 ```
 
+### S3 bucket with billing data
+
+In order to get the S3 bucket that is published by the
+[cg-billing](https://github.com/18F/cg-billing/) app, you have to get the old
+pipeline, change the org and space for where it should place the UPS, then set
+new pipeline.
+
+To change the pipeline, you use the `fly` cli.
+
+To get the pipeline, run:
+
+```sh
+fly -t {your-concourse-target} get-pipeline -p deploy-billing > deploy_billing.yml
+```
+
+To set the pipeline, run:
+
+```sh
+fly -t {your-concourse-target} set-pipeline -n -c deploy_billing.yml -p deploy-billing
+```
+
 ### Other credentials
 ```sh
 cf cups customer-django-creds -p '{"SECRET_KEY": "your-secret-key"}'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 It just uses the django-admin interface to act as the UI for the machine
 readable source of truth for customer data.
 
-https://customers.fr.cloud.gov
+[Production](https://customers.fr.cloud.gov)
+[Staging](https://customers.fr-stage.cloud.gov)
 
 Team members will need to request access to #cg-customer to have your e-mail
 added to the django database so that when login requests from this
@@ -40,7 +41,7 @@ cf create-service cloud-gov-identity-provider oauth-client \
 # Staging
 cf create-service cloud-gov-identity-provider oauth-client \
   customer-uaa-client \
-  -c '{"redirect_uri": ["https://customers-staging.fr.cloud.gov"]}'
+  -c '{"redirect_uri": ["https://customers.fr-stage.cloud.gov"]}'
 ```
 
 Next, run: `cf service customer-uaa-client` to get the fugacious link. Open the

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,16 +12,19 @@ cf -v
 go get github.com/contraband/autopilot
 cf install-plugin -f /home/ubuntu/.go_workspace/bin/autopilot
 
+CF_APP="customers"
+CF_ORGANIZATION="cloud-gov"
+
 if [ "$CIRCLE_BRANCH" == "master" ]
 then
 	CF_MANIFEST="manifest-staging.yml"
 	CF_SPACE="customer-stage"
-	CF_APP="customers-staging"
+	CF_API="https://api.fr-stage.cloud.gov"
 elif [ "$CIRCLE_BRANCH" == "production" ]
 then
 	CF_MANIFEST="manifest.yml"
 	CF_SPACE="customer-prod"
-	CF_APP="customers"
+	CF_API="https://api.fr.cloud.gov"
 else
   echo Unknown environment, quitting. >&2
   exit 1
@@ -31,7 +34,6 @@ fi
 # our deployer accounts.
 # Currently, the deployer accounts are scoped to a single space.
 # As a result, we will filter by space for which credentials to use.
-CF_ORGANIZATION="cloud-gov"
 if [ "$CF_SPACE" == "customer-prod" ]
 then
 	CF_USERNAME=$CF_USERNAME_PROD_SPACE
@@ -54,7 +56,6 @@ function deploy () {
   local space=${3}
   local app=${4}
 
-  CF_API="https://api.fr.cloud.gov"
   # Log in
   cf api $CF_API
   cf auth $CF_USERNAME $CF_PASSWORD

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -11,5 +11,6 @@ applications:
     - customer-django-creds
     - customer-db
     - customer-s3
+    - billing
   env:
     DEBUG: 'False'

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,6 +1,6 @@
 applications:
-- name: customers-staging
-  domain: fr.cloud.gov
+- name: customers
+  domain: fr-stage.cloud.gov
   instances: 1
   memory: 512M
   disk_quota: 1024M

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,5 +11,6 @@ applications:
     - customer-django-creds
     - customer-db
     - customer-s3
+    - billing
   env:
     DEBUG: 'False'


### PR DESCRIPTION
The staging app was previously deployed to the production CF environment up until this PR.

This PR addresses two parts:
1) In order to be aligned with what a staging environment is, which is to
use the staging CF env at api.fr-stage.cloud.gov. Now it targets that environment.

2) Add the reference to the UPS named "billing" which contains the credentials for the S3 bucket for platform billing data. Also, the README is updated with instructions on how to point Concourse to deploy the UPS to the desired org and space

cc: @fureigh 

Also, @rogeruiz would be proud. :)