### PR TITLE
Add deploy_billing.yml to .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -3,3 +3,4 @@ db.sqlite3
 *.pyc
 static/
 .git
+deploy_billing.yml


### PR DESCRIPTION
This pull request is a follow-up to https://github.com/18F/cg-customers/pull/5, which added `deploy_billing.yml` to `.gitignore` to guard against committing its sensitive information to the repo. This does the same in `.cfignore` to prevent accidental deployment of the same file.