### PR TITLE
edit ssh instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ to setup a superuser so they can login.
 
 ```sh
 cf ssh customers
-for f in /home/vcap/app/.profile.d/*.sh; do source "$f"; done;
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/app/.cloudfoundry/0/lib/
 cd app
-$HOME/app/.cloudfoundry/python/bin/python3 manage.py createsuperuser \
+$HOME/app/.cloudfoundry/0/python/bin/python3.6 manage.py createsuperuser \
   --username foo --email foo@example.org --noinput
 ```
 


### PR DESCRIPTION
Seems like a change to the platform changed how to use the right python once you are SSH'd into the instance. This commit just updates the instructions.